### PR TITLE
Upgrade to gradle 6.8.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Gradle and Java Compatibility
 
 | Gradle Version | Works       |
 | :------------- | :---------: |
+| 6.3            | ![yes]      |
+| 6.4            | ![yes]      |
+| 6.5            | ![yes]      |
+| 6.6            | ![yes]      |
+| 6.7            | ![yes]      |
 | 6.8.2          | ![yes]      |
 
 Development

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '1.5.0'
+    id 'net.wooga.plugins' version '2.0.0'
 }
 
 group 'net.wooga.gradle'
@@ -46,10 +46,6 @@ repositories {
 
 dependencies {
     integrationTestImplementation 'org.apache.commons:commons-text:[1.8,2)'
-    testImplementation('org.spockframework:spock-core:1.2-groovy-2.4') {
-        exclude module: 'groovy-all'
-    }
     implementation 'org.tukaani:xz:1.8'
     //compile("org.ysb33r.gradle:grolifant:0.17.0")
-    testImplementation 'com.github.stefanbirkner:system-rules:[1.18.0,2)'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -20,4 +20,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip

--- a/gradle_check_versions.sh
+++ b/gradle_check_versions.sh
@@ -1,15 +1,40 @@
 #!/usr/bin/env bash
 
-versions=("4.0" "4.1" "4.2" "4.3" "4.4" "4.5" "4.6" "4.7" "4.8" "4.9" "4.10")
+#
+# Copyright 2021 Wooga GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
+versions=("6.3" "6.4" "6.5" "6.6" "6.7")
+
+rm -fr build/reports
 for i in "${versions[@]}"
 do
     echo "test gradle version $i"
+    GRADLE_VERSION=$i ./gradlew test &> /dev/null
+    status=$?
+    mkdir -p "build/reports/$i"
+    mv build/reports/test "build/reports/$i"
+    if [ $status -ne 0 ]; then
+        echo "test error $i"
+    fi
+
     GRADLE_VERSION=$i ./gradlew integrationTest &> /dev/null
     status=$?
     mkdir -p "build/reports/$i"
     mv build/reports/integrationTest "build/reports/$i"
     if [ $status -ne 0 ]; then
-        echo "test error $i"
+        echo "integrationTest error $i"
     fi
 done

--- a/src/integrationTest/groovy/wooga/gradle/rust/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rust/IntegrationSpec.groovy
@@ -29,7 +29,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
 
     @Rule
-    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
+    public EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
     def escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()

--- a/src/integrationTest/groovy/wooga/gradle/rust/RustIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rust/RustIntegrationSpec.groovy
@@ -17,7 +17,6 @@
 package wooga.gradle.rust
 
 import wooga.gradle.rust.IntegrationSpec
-import wooga.gradle.rust.RustBasePlugin
 
 class RustIntegrationSpec extends IntegrationSpec {
 


### PR DESCRIPTION
## Description

This patch upgrades the whole plugin to be based on gradle 6.8.3. It will not be aimed to be backwards compatible with gradle older than version `5.0`.

## Changes

* ![UPDATE] ![GRADLE] to version `6.8.3`
* ![BREAK] ![GRADLE] supported backwards compatibility

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"