### PR TITLE
Add rustup plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,11 +33,17 @@ pluginBundle {
 
 gradlePlugin {
     plugins {
-        plugins {
+        rustLib {
             id = 'net.wooga.rust.lib'
             displayName = 'Rust Library plugin'
             description = 'A simple gradle plugin to build rust library crates'
             implementationClass = 'wooga.gradle.rust.RustLibraryPlugin'
+        }
+        rustup {
+            id = 'net.wooga.rustup'
+            displayName = 'RustUp toolchain installer plugin'
+            description = 'The gradle wrapper for the rustup toolchain installer'
+            implementationClass = 'wooga.gradle.rustup.RustupPlugin'
         }
     }
 }
@@ -58,4 +64,6 @@ dependencies {
     integrationTestImplementation 'org.apache.commons:commons-text:[1.8,2)'
     implementation 'org.tukaani:xz:1.8'
     implementation 'org.ysb33r.gradle:grolifant60:1.3.2'
+    implementation 'com.wooga.gradle:gradle-commons:[1.5.1,2['
+    testImplementation 'com.wooga.gradle:gradle-commons-test:[1.9,2['
 }

--- a/src/integrationTest/groovy/wooga/gradle/rustup/RustupIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rustup/RustupIntegrationSpec.groovy
@@ -1,0 +1,21 @@
+package wooga.gradle.rustup
+
+import com.wooga.gradle.test.IntegrationSpec
+
+
+class RustupIntegrationSpec extends IntegrationSpec {
+    def setup() {
+        def gradleVersion = System.getenv("GRADLE_VERSION")
+        if (gradleVersion) {
+            this.gradleVersion = gradleVersion
+            fork = true
+        }
+    }
+
+    static wrapValueFallback = { Object rawValue, String type, Closure<String> fallback ->
+        switch (type) {
+            default:
+                return rawValue.toString()
+        }
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/rustup/RustupPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rustup/RustupPluginIntegrationSpec.groovy
@@ -1,0 +1,59 @@
+package wooga.gradle.rustup
+
+import com.wooga.gradle.test.PropertyLocation
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetInvocation
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import spock.lang.Unroll
+
+class RustupPluginIntegrationSpec extends RustupIntegrationSpec {
+
+    def setup() {
+        buildFile << """
+          ${applyPlugin(RustupPlugin)}
+       """.stripIndent()
+    }
+
+    @Unroll()
+    def "rustup task property #property of type #type sets #rawValue when #location"() {
+        given:
+        environmentVariables.clear("CARGO_HOME", "RUSTUP_HOME")
+
+        expect:
+        runPropertyQuery(get, set).matches(rawValue)
+
+        where:
+        property     | method                            | rawValue                                           | type                    | location
+        "cargoHome"  | PropertySetInvocation.assignment  | osPath("/path/to/cargo_home")                      | "File"                  | PropertyLocation.script
+        "cargoHome"  | PropertySetInvocation.assignment  | osPath("/path/to/cargo_home")                      | "Provider<Directory>"   | PropertyLocation.script
+        "cargoHome"  | PropertySetInvocation.providerSet | osPath("/path/to/cargo_home")                      | "File"                  | PropertyLocation.script
+        "cargoHome"  | PropertySetInvocation.providerSet | osPath("/path/to/cargo_home")                      | "Provider<Directory>"   | PropertyLocation.script
+        "cargoHome"  | PropertySetInvocation.setter      | osPath("/path/to/cargo_home")                      | "File"                  | PropertyLocation.script
+        "cargoHome"  | PropertySetInvocation.setter      | osPath("/path/to/cargo_home")                      | "Provider<Directory>"   | PropertyLocation.script
+        "cargoHome"  | _                                 | System.getenv("HOME") + File.separator + ".cargo"  | _                       | PropertyLocation.none
+
+        "rustupHome" | PropertySetInvocation.assignment  | osPath("/path/to/rustup_home")                     | "File"                  | PropertyLocation.script
+        "rustupHome" | PropertySetInvocation.assignment  | osPath("/path/to/rustup_home")                     | "Provider<Directory>"   | PropertyLocation.script
+        "rustupHome" | PropertySetInvocation.providerSet | osPath("/path/to/rustup_home")                     | "File"                  | PropertyLocation.script
+        "rustupHome" | PropertySetInvocation.providerSet | osPath("/path/to/rustup_home")                     | "Provider<Directory>"   | PropertyLocation.script
+        "rustupHome" | PropertySetInvocation.setter      | osPath("/path/to/rustup_home")                     | "File"                  | PropertyLocation.script
+        "rustupHome" | PropertySetInvocation.setter      | osPath("/path/to/rustup_home")                     | "Provider<Directory>"   | PropertyLocation.script
+        "rustupHome" | _                                 | System.getenv("HOME") + File.separator + ".rustup" | _                       | PropertyLocation.none
+
+        "logFile"    | PropertySetInvocation.assignment  | osPath("/custom/logs/log1.log")                    | "File"                  | PropertyLocation.script
+        "logFile"    | PropertySetInvocation.assignment  | osPath("/custom/logs/log2.log")                    | "Provider<RegularFile>" | PropertyLocation.script
+        "logFile"    | PropertySetInvocation.providerSet | osPath("/custom/logs/log3.log")                    | "File"                  | PropertyLocation.script
+        "logFile"    | PropertySetInvocation.providerSet | osPath("/custom/logs/log4.log")                    | "Provider<RegularFile>" | PropertyLocation.script
+        "logFile"    | PropertySetInvocation.setter      | osPath("/custom/logs/log5.log")                    | "File"                  | PropertyLocation.script
+        "logFile"    | PropertySetInvocation.setter      | osPath("/custom/logs/log6.log")                    | "Provider<RegularFile>" | PropertyLocation.script
+
+        extensionName = "xcodebuild"
+        set = new PropertySetterWriter("rustup", property)
+                .serialize(wrapValueFallback)
+                .set(rawValue, type)
+                .to(location)
+                .use(method)
+
+        get = new PropertyGetterTaskWriter(set)
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/rustup/RustupTaskIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rustup/RustupTaskIntegrationSpec.groovy
@@ -1,0 +1,44 @@
+package wooga.gradle.rustup
+
+import wooga.gradle.rust.IntegrationSpec
+
+import java.lang.reflect.ParameterizedType
+
+class RustupTaskIntegrationSpec<T> extends RustupIntegrationSpec {
+    Class<T> getSubjectUnderTestClass() {
+        if (!_sutClass) {
+            try {
+                this._sutClass = (Class<T>) ((ParameterizedType) this.getClass().getGenericSuperclass())
+                        .getActualTypeArguments()[0];
+            }
+            catch (Exception e) {
+                this._sutClass = (Class<T>) null
+            }
+        }
+        _sutClass
+    }
+    private Class<T> _sutClass
+
+    String getSubjectUnderTestName() {
+        "${subjectUnderTestClass.simpleName.uncapitalize()}Test"
+    }
+
+    String getSubjectUnderTestTypeName() {
+        subjectUnderTestClass.getTypeName()
+    }
+
+    def setup() {
+        buildFile << """
+        task ${subjectUnderTestName}(type: ${subjectUnderTestTypeName}) {
+        }
+        """.stripIndent()
+    }
+
+    void appendToSubjectTask(String... lines) {
+        buildFile << """
+        $subjectUnderTestName {
+            ${lines.join('\n')}
+        }
+        """.stripIndent()
+    }
+}

--- a/src/integrationTest/groovy/wooga/gradle/rustup/tasks/RustupInstallIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rustup/tasks/RustupInstallIntegrationSpec.groovy
@@ -1,0 +1,290 @@
+package wooga.gradle.rustup.tasks
+
+import com.wooga.gradle.PlatformUtils
+import com.wooga.gradle.test.PropertyQueryTaskWriter
+import com.wooga.gradle.test.writers.PropertyGetterTaskWriter
+import com.wooga.gradle.test.writers.PropertySetterWriter
+import spock.lang.Unroll
+import wooga.gradle.rustup.RustupTaskIntegrationSpec
+
+import static com.wooga.gradle.test.PropertyUtils.toSetter
+import static com.wooga.gradle.test.writers.PropertySetInvocation.*
+
+class RustupInstallIntegrationSpec extends RustupTaskIntegrationSpec<Rustup> {
+
+    @Unroll("property #property #valueMessage sets flag #expectedCommandlineFlag")
+    def "constructs arguments"() {
+        given: "a set property"
+        if (method != _) {
+            buildFile << """
+            ${subjectUnderTestName}.${invocation}($value)
+            """.stripIndent()
+        }
+
+        when:
+        def query = new PropertyQueryTaskWriter("${subjectUnderTestName}.arguments", ".get().join(\" \")")
+        query.write(buildFile)
+        def result = runTasksSuccessfully(query.taskName)
+
+        then:
+        outputContains(result, expectedCommandlineFlag)
+
+        where:
+        property              | invocation               | rawValue                                             | type           || expectedCommandlineFlag
+        "defaultHost"         | toSetter(property)       | "x86_64-unknown-linux-gnu"                           | "String"       || "--default-host ${rawValue}"
+        "defaultToolchain"    | toSetter(property)       | "stable"                                             | "String"       || "--default-toolchain ${rawValue}"
+        "profile"             | toSetter(property)       | "minimal"                                            | "String"       || "--${property} ${rawValue}"
+        "additionalArguments" | "setAdditionalArguments" | ["--verbose", "--foo bar"]                           | "List<String>" || "--verbose --foo bar"
+        "components"          | "components"             | ["1", "2", "3"]                                      | "List<String>" || "--component 1 --component 2 --component 3"
+        "target"              | "targets"                | ["x86_64-unknown-linux-gnu", "x86_64-linux-android"] | "List<String>" || "--target x86_64-unknown-linux-gnu --target x86_64-linux-android"
+        value = wrapValueBasedOnType(rawValue, type)
+        valueMessage = (rawValue != _) ? "with value ${value}" : "without value"
+    }
+
+    @Unroll("can set property #property with #invocation and type #type")
+    def "can set property"() {
+        expect:
+        runPropertyQuery(get, set).matches(rawValue)
+
+        where:
+        property           | invocation  | rawValue                   | type
+        "defaultHost"      | providerSet | "x86_64-unknown-linux-gnu" | "String"
+        "defaultHost"      | providerSet | "x86_64-unknown-linux-gnu" | "Provider<String>"
+        "defaultHost"      | setter      | "x86_64-unknown-linux-gnu" | "String"
+        "defaultHost"      | setter      | "x86_64-unknown-linux-gnu" | "Provider<String>"
+
+        "defaultToolchain" | providerSet | "stable"                   | "String"
+        "defaultToolchain" | providerSet | "stable"                   | "Provider<String>"
+        "defaultToolchain" | setter      | "stable"                   | "String"
+        "defaultToolchain" | setter      | "stable"                   | "Provider<String>"
+
+        "profile"          | providerSet | "minimal"                  | "String"
+        "profile"          | providerSet | "minimal"                  | "Provider<String>"
+        "profile"          | setter      | "minimal"                  | "String"
+        "profile"          | setter      | "minimal"                  | "Provider<String>"
+
+        "rustupHome"       | providerSet | osPath("/some/path/to")            | "File"
+        "rustupHome"       | providerSet | osPath("/some/path/to")            | "Provider<Directory>"
+        "rustupHome"       | setter      | osPath("/some/path/to")            | "File"
+        "rustupHome"       | setter      | osPath("/some/path/to")            | "Provider<Directory>"
+
+        "cargoHome"        | providerSet | osPath("/some/path/to")            | "File"
+        "cargoHome"        | providerSet | osPath("/some/path/to")            | "Provider<Directory>"
+        "cargoHome"        | setter      | osPath("/some/path/to")            | "File"
+        "cargoHome"        | setter      | osPath("/some/path/to")            | "Provider<Directory>"
+
+        set = new PropertySetterWriter(subjectUnderTestName, property)
+                .set(rawValue, type)
+                .toScript(invocation)
+                .serialize(wrapValueFallback)
+
+        get = new PropertyGetterTaskWriter(set)
+    }
+
+    private static executableName(String name) {
+        PlatformUtils.isWindows() ? "${name}.exe" : name
+    }
+
+    def "installs rustup"() {
+        given:
+        def tempRustupHome = File.createTempDir("rustup", "home")
+        def tempCargoHome = File.createTempDir("cargo", "home")
+
+        and: "future files"
+        File rustup = new File(tempCargoHome, executableName("bin/rustup"))
+        File cargo = new File(tempCargoHome, executableName("bin/cargo"))
+        assert !rustup.exists()
+        assert !cargo.exists()
+
+        and: "a default toolchain"
+        appendToSubjectTask("""
+            defaultToolchain='stable'
+            rustupHome = ${wrapValueBasedOnType(tempRustupHome, "File")}
+            cargoHome = ${wrapValueBasedOnType(tempCargoHome, "File")}
+        """.stripIndent())
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        rustup.exists()
+        rustup.canExecute()
+
+        cargo.exists()
+        cargo.canExecute()
+    }
+
+    def listInstalledTargets(File rustupHome, File cargoHome) {
+        def out = new ByteArrayOutputStream()
+        def err = new ByteArrayOutputStream()
+        File rustup = new File(cargoHome, executableName("bin/rustup"))
+        "${rustup.absolutePath} target list --installed".execute(["RUSTUP_HOME=${rustupHome.absolutePath}", "CARGO_HOME=${cargoHome.absolutePath}"], null).waitForProcessOutput(out, err)
+
+        out.toString().readLines()
+    }
+
+    def listInstalledComponents(File rustupHome, File cargoHome) {
+        def out = new ByteArrayOutputStream()
+        def err = new ByteArrayOutputStream()
+        File rustup = new File(cargoHome, executableName("bin/rustup"))
+        "${rustup.absolutePath} component list --installed".execute(["RUSTUP_HOME=${rustupHome.absolutePath}", "CARGO_HOME=${cargoHome.absolutePath}"], null).waitForProcessOutput(out, err)
+
+        out.toString().readLines()
+    }
+
+    def installRustup(File rustupHome, File cargoHome) {
+        def out = new ByteArrayOutputStream()
+        def err = new ByteArrayOutputStream()
+        String postfixName = PlatformUtils.isWindows() ? ".exe" : "init.sh"
+        String prefixName = PlatformUtils.isWindows() ? "rustup-init" : "rustup"
+        File rustupInstallScript = File.createTempFile(prefixName, postfixName)
+
+        def url = new URL(PlatformUtils.isWindows() ? "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe" : "https://sh.rustup.rs")
+        url.withInputStream { i ->
+            rustupInstallScript.withOutputStream {
+                it << i
+            }
+        }
+        rustupInstallScript.setExecutable(true)
+        def p = "${rustupInstallScript.absolutePath} -y --no-modify-path --profile=minimal".execute(["RUSTUP_HOME=${rustupHome.absolutePath}", "CARGO_HOME=${cargoHome.absolutePath}"], null)
+        p.waitForProcessOutput(out, err)
+        if (p.exitValue() != 0) {
+            throw new Exception("rustup install failed")
+        }
+    }
+
+    def "installs rustup with targets"() {
+        given:
+        def tempRustupHome = File.createTempDir("rustup", "home")
+        def tempCargoHome = File.createTempDir("cargo", "home")
+
+        and: "future files"
+        File rustup = new File(tempCargoHome, "bin/rustup")
+        File cargo = new File(tempCargoHome, "bin/cargo")
+        assert !rustup.exists()
+        assert !cargo.exists()
+
+        and: "a default toolchain"
+        appendToSubjectTask("""
+            defaultToolchain='stable'
+            rustupHome = ${wrapValueBasedOnType(tempRustupHome, "File")}
+            cargoHome = ${wrapValueBasedOnType(tempCargoHome, "File")}
+            targets = ${wrapValueBasedOnType(targets, "List<String>")} 
+        """.stripIndent())
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        listInstalledTargets(tempRustupHome, tempCargoHome).containsAll(targets)
+
+        where:
+        targets = ["aarch64-apple-darwin", "x86_64-apple-darwin"]
+    }
+
+    def "installs rustup with components"() {
+        given:
+        def tempRustupHome = File.createTempDir("rustup", "home")
+        def tempCargoHome = File.createTempDir("cargo", "home")
+
+        and: "future files"
+        File rustup = new File(tempCargoHome, executableName("bin/rustup"))
+        File cargo = new File(tempCargoHome, executableName("bin/cargo"))
+        assert !rustup.exists()
+        assert !cargo.exists()
+
+        and: "a default toolchain"
+        appendToSubjectTask("""
+            defaultToolchain='stable'
+            rustupHome = ${wrapValueBasedOnType(tempRustupHome, "File")}
+            cargoHome = ${wrapValueBasedOnType(tempCargoHome, "File")}
+            components = ${wrapValueBasedOnType(components, "List<String>")} 
+        """.stripIndent())
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        listInstalledComponents(tempRustupHome, tempCargoHome).any { component ->
+            components.any { component.startsWith(it) }
+        }
+
+        where:
+        components = ['rls', 'rust-analysis']
+    }
+
+    def "installs rustup missing components"() {
+        given:
+        def tempRustupHome = File.createTempDir("rustup", "home")
+        tempRustupHome.deleteOnExit()
+        def tempCargoHome = File.createTempDir("cargo", "home")
+        tempRustupHome.deleteOnExit()
+
+        and: "future files"
+        File rustup = new File(tempCargoHome, executableName("bin/rustup"))
+        File cargo = new File(tempCargoHome, executableName("bin/cargo"))
+        assert !rustup.exists()
+        assert !cargo.exists()
+
+        and: "a rustup installation"
+        installRustup(tempRustupHome, tempCargoHome)
+
+        assert !listInstalledTargets(tempRustupHome, tempCargoHome).containsAll(targets)
+        assert !listInstalledComponents(tempRustupHome, tempCargoHome).any { component ->
+            components.any { component.startsWith(it) }
+        }
+
+        and:
+        appendToSubjectTask("""
+            rustupHome = ${wrapValueBasedOnType(tempRustupHome, "File")}
+            cargoHome = ${wrapValueBasedOnType(tempCargoHome, "File")}
+            components = ${wrapValueBasedOnType(components, "List<String>")}
+            targets = ${wrapValueBasedOnType(targets, "List<String>")}
+        """.stripIndent())
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        rustup.exists()
+        rustup.canExecute()
+
+        cargo.exists()
+        cargo.canExecute()
+
+        listInstalledComponents(tempRustupHome, tempCargoHome).any { component ->
+            components.any { component.startsWith(it) }
+        }
+
+        listInstalledTargets(tempRustupHome, tempCargoHome).containsAll(targets)
+
+        where:
+        components = ['rls']
+        targets = ["riscv32i-unknown-none-elf", "powerpc-unknown-linux-gnu"]
+    }
+
+    def "update runs rustup update and self update"() {
+        given:
+        def tempRustupHome = File.createTempDir("rustup", "home")
+        tempRustupHome.deleteOnExit()
+        def tempCargoHome = File.createTempDir("cargo", "home")
+        tempRustupHome.deleteOnExit()
+
+        and: "a rustup installation"
+        installRustup(tempRustupHome, tempCargoHome)
+
+        and:
+        appendToSubjectTask("""
+            rustupHome = ${wrapValueBasedOnType(tempRustupHome, "File")}
+            cargoHome = ${wrapValueBasedOnType(tempCargoHome, "File")}
+            update = true
+        """.stripIndent())
+
+        when:
+        def result = runTasksSuccessfully(subjectUnderTestName)
+
+        then:
+        result.standardOutput.contains("update rustup")
+
+    }
+}

--- a/src/main/groovy/wooga/gradle/rust/SupportedOs.groovy
+++ b/src/main/groovy/wooga/gradle/rust/SupportedOs.groovy
@@ -35,7 +35,7 @@ enum SupportedOs {
             [AARCH_64, ARM, MIPS, MIPS_64, MIPS_64_EL, MIPS_EL, PPC, PPC_64, PPC_64_LE, S390, X86, X86_64],
             [GNU, GNU_EABI, GNU_EABIHF, GNU_ABI64]
     ),
-    MACOS('darwin', 'apple', [X86, X86_64]),
+    MACOS('darwin', 'apple', [X86_64, X86, AARCH_64]),
     NETBSD('netbsd', 'unknown', [X86_64]),
     WINDOWS('windows', 'pc', [X86, X86_64], [MSVC, GNU])
 

--- a/src/main/groovy/wooga/gradle/rust/internal/RustInstaller.groovy
+++ b/src/main/groovy/wooga/gradle/rust/internal/RustInstaller.groovy
@@ -145,6 +145,12 @@ class RustInstaller extends AbstractDistributionInstaller implements ExecutableD
         this.rustOs = os
         this.rustArch = arch
         this.rustAbi = abi
+        this.installerPackageExtension = (OS.windows) ? ".msi" : ".tar.gz"
+        this.rustcPathPart = (OS.windows) ? "bin/rustc.exe" : "bin/rustc"
+        this.cargoPathPart = (OS.windows) ? "bin/cargo.exe" : "bin/cargo"
+        if (!rustOs.validAbi(rustAbi)) {
+            throw new UnsupportedConfigurationException(rustOs, rustAbi)
+        }
     }
 
     /** Obtains a download URI for Rust distribution given a specific version.

--- a/src/main/groovy/wooga/gradle/rustup/RustupPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/rustup/RustupPlugin.groovy
@@ -1,0 +1,23 @@
+package wooga.gradle.rustup
+
+import com.wooga.gradle.PlatformUtils
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import wooga.gradle.rustup.tasks.Rustup
+
+class RustupPlugin implements Plugin<Project> {
+
+    static final String EXTENSION_NAME = "rustup"
+
+    @Override
+    void apply(Project project) {
+        project.tasks.register("rustup", Rustup) {
+            def cargoHomeDefault = System.getenv("CARGO_HOME") ?: (PlatformUtils.isWindows() ? System.getenv("USERPROFILE") : System.getenv("HOME")) + "/.cargo"
+            def rustupHomeDefault = System.getenv("RUSTUP_HOME") ?: (PlatformUtils.isWindows() ? System.getenv("USERPROFILE") : System.getenv("HOME")) + "/.rustup"
+
+            cargoHome.convention(project.layout.projectDirectory.dir(cargoHomeDefault))
+            rustupHome.convention(project.layout.projectDirectory.dir(rustupHomeDefault))
+            logFile.convention(project.layout.buildDirectory.file("logs/${it.name}.log"))
+        }
+    }
+}

--- a/src/main/groovy/wooga/gradle/rustup/RustupSpec.groovy
+++ b/src/main/groovy/wooga/gradle/rustup/RustupSpec.groovy
@@ -1,0 +1,161 @@
+package wooga.gradle.rustup
+
+import com.wooga.gradle.BaseSpec
+import org.gradle.api.file.Directory
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+
+trait RustupSpec extends BaseSpec {
+
+    private final DirectoryProperty cargoHome = objects.directoryProperty()
+
+    @OutputDirectory
+    DirectoryProperty getCargoHome() {
+        cargoHome
+    }
+
+    void setCargoHome(Provider<Directory> value) {
+        cargoHome.set(value)
+    }
+
+    void setCargoHome(File value) {
+        cargoHome.set(value)
+    }
+
+    private final DirectoryProperty rustupHome = objects.directoryProperty()
+
+    @OutputDirectory
+    DirectoryProperty getRustupHome() {
+        rustupHome
+    }
+
+    void setRustupHome(Provider<Directory> value) {
+        rustupHome.set(value)
+    }
+
+    void setRustupHome(File value) {
+        rustupHome.set(value)
+    }
+
+    private final ListProperty<String> targets = objects.listProperty(String)
+
+
+    @Internal
+    ListProperty<String> getTargets() {
+        targets
+    }
+
+    void setTargets(Provider<Iterable<String>> values) {
+        targets.set(values)
+    }
+
+    void setTargets(Iterable<String> values) {
+        targets.set(values)
+    }
+
+    void target(String value) {
+        targets.add(value)
+    }
+
+    void targets(String... values) {
+        targets.addAll(values)
+    }
+
+    void targets(Iterable<String> values) {
+        targets.addAll(values)
+    }
+
+    private final Property<String> defaultHost = objects.property(String)
+
+    @Internal
+    Property<String> getDefaultHost() {
+        defaultHost
+    }
+
+    void setDefaultHost(Provider<String> value) {
+        defaultHost.set(value)
+    }
+
+    void setDefaultHost(String value) {
+        defaultHost.set(value)
+    }
+
+    private final Property<String> defaultToolchain = objects.property(String)
+
+    @Internal
+    Property<String> getDefaultToolchain() {
+        defaultToolchain
+    }
+
+    void setDefaultToolchain(Provider<String> value) {
+        defaultToolchain.set(value)
+    }
+
+    void setDefaultToolchain(String value) {
+        defaultToolchain.set(value)
+    }
+
+    private final ListProperty<String> components = objects.listProperty(String)
+
+    @Internal
+    ListProperty<String> getComponents() {
+        components
+    }
+
+    void setComponents(Provider<Iterable<String>> values) {
+        components.set(values)
+    }
+
+    void setComponents(Iterable<String> values) {
+        components.set(values)
+    }
+
+    void component(String value) {
+        components.add(value)
+    }
+
+    void components(String... values) {
+        components.addAll(values)
+    }
+
+    void components(Iterable<String> values) {
+        components.addAll(values)
+    }
+
+    private final Property<String> profile = objects.property(String)
+
+    @Internal
+    Property<String> getProfile() {
+        profile
+    }
+
+    void setProfile(Provider<String> value) {
+        profile.set(value)
+    }
+
+    void setProfile(String value) {
+        profile.set(value)
+    }
+
+    private final Property<Boolean> update = objects.property(Boolean)
+
+    @Input
+    @Optional
+    Property<Boolean> getUpdate() {
+        update
+    }
+
+    void setUpdate(Provider<Boolean> value) {
+        update.set(value)
+    }
+
+    void setUpdate(Boolean value) {
+        update.set(value)
+    }
+}

--- a/src/main/groovy/wooga/gradle/rustup/tasks/Rustup.groovy
+++ b/src/main/groovy/wooga/gradle/rustup/tasks/Rustup.groovy
@@ -1,0 +1,120 @@
+package wooga.gradle.rustup.tasks
+
+import com.wooga.gradle.ArgumentsSpec
+import com.wooga.gradle.PlatformUtils
+import com.wooga.gradle.io.LogFileSpec
+import com.wooga.gradle.io.ProcessExecutor
+import com.wooga.gradle.io.ProcessOutputSpec
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFile
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecResult
+import wooga.gradle.rustup.RustupSpec
+
+class Rustup extends DefaultTask implements RustupSpec, ArgumentsSpec, LogFileSpec, ProcessOutputSpec {
+
+    Rustup() {
+        internalArguments = project.provider({
+            List<String> arguments = new ArrayList<String>()
+            arguments << "-y" << "--no-modify-path"
+
+            if (defaultHost.isPresent()) {
+                arguments << "--default-host" << defaultHost.get()
+            }
+
+            arguments << "--default-toolchain" << defaultToolchain.getOrElse("none")
+
+            if (profile.present) {
+                arguments << "--profile" << profile.get()
+            }
+
+            if (components.present) {
+                components.get().each {
+                    arguments << "--component" << it
+                }
+            }
+
+            if (targets.present) {
+                targets.get().each {
+                    arguments << "--target" << it
+                }
+            }
+
+            arguments as List<String>
+        })
+
+        environment.set(cargoHome.zip(rustupHome, { cargoHome, rustupHome ->
+            [
+                    "CARGO_HOME" : cargoHome.asFile.absolutePath,
+                    "RUSTUP_HOME": rustupHome.asFile.absolutePath
+            ]
+        }))
+
+        rustup = cargoHome.file(providers.provider({
+            PlatformUtils.isWindows() ? "bin/rustup.exe" : "bin/rustup"
+        }))
+
+        outputs.upToDateWhen { false }
+    }
+
+    private final Provider<RegularFile> rustup
+
+    @TaskAction
+    void rustupInstall() {
+        File rustup = rustup.get().asFile
+        if (!rustup.exists()) {
+            logger.info("setup rustup")
+            String postfixName = PlatformUtils.isWindows() ? ".exe" : "init.sh"
+            String prefixName = PlatformUtils.isWindows() ? "rustup-init" : "rustup"
+            File rustupInstallScript = File.createTempFile(prefixName, postfixName)
+
+            def url = new URL(PlatformUtils.isWindows() ? "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe" : "https://sh.rustup.rs")
+            url.withInputStream { i ->
+                rustupInstallScript.withOutputStream {
+                    it << i
+                }
+            }
+            rustupInstallScript.setExecutable(true)
+
+            ProcessExecutor executor = ProcessExecutor.from(project)
+                    .withExecutable(rustupInstallScript)
+                    .withArguments(this, true)
+                    .withOutput(this, logFile.asFile.getOrNull())
+                    .withOutputLogFile(this, this)
+
+            executor.execute()
+        } else {
+            logger.info("rustup already installed.")
+            if (update.present && update.get()) {
+                logger.info("update rustup")
+                runRustupCommand("self", "update")
+                runRustupCommand("update")
+            }
+
+            targets.get().each { target ->
+                runRustupCommand("target", "add", target)
+            }
+
+            components.get().each { component ->
+                runRustupCommand("component", "add", component)
+            }
+
+            if (defaultToolchain.present) {
+                def toolchain = defaultToolchain.get()
+                runRustupCommand("toolchain", "install", toolchain)
+                runRustupCommand("default", toolchain)
+            }
+        }
+    }
+
+    ExecResult runRustupCommand(String... arguments) {
+        ProcessExecutor executor = ProcessExecutor.from(project)
+                .withExecutable(rustup.get().asFile.absolutePath)
+                .withArguments(arguments)
+                .withEnvironment(environment.get())
+                .withOutput(this, logFile.asFile.getOrNull())
+                .withOutputLogFile(this, this)
+        executor.execute()
+    }
+}


### PR DESCRIPTION
## Description

This patch adds an additional plugin to work with rustup. This solved some issues with the single toolchain installtion from the rust plugin. I think after some tests that the default
tool installtion will be with rustup by default since cross compilation becomes easier.

## Changes

* ![ADD] `rustup` plugin