### PR TITLE
Fix cargo compile task output dir based on selected target

### DIFF
--- a/src/main/groovy/wooga/gradle/rust/tasks/AbstractRustCompile.groovy
+++ b/src/main/groovy/wooga/gradle/rust/tasks/AbstractRustCompile.groovy
@@ -56,7 +56,14 @@ abstract class AbstractRustCompile extends AbstractRustLifecycleTask {
 
     @OutputDirectory
     Provider<Directory> getOutputDir() {
-        workingDir.dir("target/${release.getOrElse(false) ? 'release' : 'debug'}")
+        def config = release.getOrElse(false) ? 'release': 'debug'
+        def path = "target"
+        if(target.present) {
+            path += "/${target.get()}"
+        }
+        path += "/${config}"
+
+        workingDir.dir(path)
     }
 
     @Input


### PR DESCRIPTION
## Description

The `outputDir` property was declared with a semi static value for the output location of the compiled files. Cargo will put the output for specificly selected targets with the `--target` option into a custom dirctory under the `target` directory.

I fixed the calcuation by making the path depending on both the selected target and the `release` flag.

## Changes

* ![FIX] cargo complile task output dir based on selected target

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"