### PR TITLE
Fix missing RUSTUP_HOME setting when it is not located at default location

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/rust/RustLibProjectIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/rust/RustLibProjectIntegrationSpec.groovy
@@ -171,6 +171,14 @@ class RustLibProjectIntegrationSpec extends RustIntegrationSpec {
         "cargoHome"            | "cargoHome.set"            | osPath("build/custom/cargoHome")       | osPath("#projectDir#/build/custom/cargoHome")       | "Provider<Directory>"   | PropertyLocation.script   | " as relative path"
         "cargoHome"            | "cargoHome"                | osPath("build/custom/cargoHome")       | osPath("#projectDir#/build/custom/cargoHome")       | "File"                  | PropertyLocation.script   | " as relative path"
         "cargoHome"            | "cargoHome"                | osPath("build/custom/cargoHome")       | osPath("#projectDir#/build/custom/cargoHome")       | "Provider<Directory>"   | PropertyLocation.script   | " as relative path"
+
+
+        "rustupHome"           | _                          | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "File"                  | PropertyLocation.script   | " as relative path"
+        "rustupHome"           | _                          | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "Provider<Directory>"   | PropertyLocation.script   | " as relative path"
+        "rustupHome"           | "rustupHome.set"           | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "File"                  | PropertyLocation.script   | " as relative path"
+        "rustupHome"           | "rustupHome.set"           | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "Provider<Directory>"   | PropertyLocation.script   | " as relative path"
+        "rustupHome"           | "rustupHome"               | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "File"                  | PropertyLocation.script   | " as relative path"
+        "rustupHome"           | "rustupHome"               | osPath("build/custom/rustupHome")      | osPath("#projectDir#/build/custom/rustupHome")      | "Provider<Directory>"   | PropertyLocation.script   | " as relative path"
         //"cargoHome"         | _                       | _                              | "#projectDir#/build/rust-project"           | _                       | PropertyLocation.none     | ""
 
         //"rustcPath"            | _                          | "/custom/cargoHome"            | _                                           | _                       | PropertyLocation.env      | ""

--- a/src/main/groovy/wooga/gradle/rust/CargoActionSpec.groovy
+++ b/src/main/groovy/wooga/gradle/rust/CargoActionSpec.groovy
@@ -108,6 +108,14 @@ interface CargoActionSpec<T extends CargoActionSpec> {
     T cargoHome(File value)
     T cargoHome(Provider<Directory> value)
 
+    DirectoryProperty getRustupHome()
+
+    void setRustupHome(File value)
+    void setRustupHome(Provider<Directory> value)
+
+    T rustupHome(File value)
+    T rustupHome(Provider<Directory> value)
+
     ConfigurableFileCollection getSearchPath()
 
     void setSearchPath(Iterable<Object> value)

--- a/src/main/groovy/wooga/gradle/rust/RustBasePlugin.groovy
+++ b/src/main/groovy/wooga/gradle/rust/RustBasePlugin.groovy
@@ -121,6 +121,7 @@ class RustBasePlugin implements Plugin<Project> {
         final ReportingExtension reportingExtension = (ReportingExtension) project.getExtensions().getByName(ReportingExtension.NAME)
         extension.reportsDir.convention(project.layout.dir(project.provider({ reportingExtension.file("rust") })))
         extension.target.convention(lookupValueInEnvAndPropertiesProvider(RustConsts.TARGET))
+        extension.rustupHome.convention(lookupDirectoryValueInEnvAndPropertiesProvider(RustConsts.RUSTUP_HOME ))
         extension
     }
 

--- a/src/main/groovy/wooga/gradle/rust/RustConsts.groovy
+++ b/src/main/groovy/wooga/gradle/rust/RustConsts.groovy
@@ -35,5 +35,6 @@ class RustConsts {
 
     static final PropertyLookup<String> VERSION = new PropertyLookup<>("RUST_VERSION", "rust.version", "1.50.0")
     static final PropertyLookup<String> TARGET = new PropertyLookup<>("RUST_TARGET", "rust.target", null)
+    static final PropertyLookup<File> RUSTUP_HOME = new PropertyLookup<>("RUST_RUSTUP_HOME", "rust.rustupHome", null)
     static final PropertyLookup<Boolean> USE_LOCAL_INSTALLATION = new PropertyLookup<>("RUST_USE_LOCAL_INSTALLATION", "rust.useLocalInstallation", false)
 }

--- a/src/main/groovy/wooga/gradle/rust/RustPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/rust/RustPluginExtension.groovy
@@ -89,6 +89,14 @@ interface RustPluginExtension<T extends RustPluginExtension> {
     T cargoHome(File value)
     T cargoHome(Provider<Directory> value)
 
+    DirectoryProperty getRustupHome()
+
+    void setRustupHome(File value)
+    void setRustupHome(Provider<Directory> value)
+
+    T rustupHome(File value)
+    T rustupHome(Provider<Directory> value)
+
     FileCollection getAbiToolsSearchPath()
 
     void setAbiToolsSearchPath(Iterable<Object> value)

--- a/src/main/groovy/wooga/gradle/rust/internal/AbstractRustPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/rust/internal/AbstractRustPlugin.groovy
@@ -69,6 +69,7 @@ abstract class AbstractRustPlugin implements Plugin<Project> {
                 t.manifest.convention(copyManifestTask.destination)
                 t.logFile.convention(extension.logsDir.file("${t.name}.log"))
                 t.cargoHome.convention(extension.cargoHome)
+                t.rustupHome.convention(extension.rustupHome)
                 t.cargoPath.convention(extension.cargoPath)
                 t.searchPath.setFrom(extension.searchPath)
                 t.target.convention(extension.target)

--- a/src/main/groovy/wooga/gradle/rust/internal/DefaultRustPluginExtension.groovy
+++ b/src/main/groovy/wooga/gradle/rust/internal/DefaultRustPluginExtension.groovy
@@ -50,6 +50,7 @@ class DefaultRustPluginExtension implements RustPluginExtension {
         reportsDir = project.objects.directoryProperty()
         manifest = project.objects.fileProperty()
         cargoHome = project.objects.directoryProperty()
+        rustupHome = project.objects.directoryProperty()
         cargoHome.convention(project.layout.dir(project.provider({
             if (useLocalInstallation.present && useLocalInstallation.get()) {
                 rustToolsExtension.executableBySearchPath("rustc")
@@ -277,6 +278,34 @@ class DefaultRustPluginExtension implements RustPluginExtension {
         this
     }
 
+    private final DirectoryProperty rustupHome
+
+    @Override
+    DirectoryProperty getRustupHome() {
+        rustupHome
+    }
+
+    @Override
+    void setRustupHome(File value) {
+        rustupHome.set(value)
+    }
+
+    @Override
+    void setRustupHome(Provider value) {
+        rustupHome.set(value)
+    }
+
+    @Override
+    RustPluginExtension rustupHome(File value) {
+        setRustupHome(value)
+        this
+    }
+
+    @Override
+    RustPluginExtension rustupHome(Provider value) {
+        setRustupHome(value)
+        this
+    }
     private final ConfigurableFileCollection abiToolsSearchPath
 
     @Override

--- a/src/main/groovy/wooga/gradle/rust/tasks/AbstractCargoTask.groovy
+++ b/src/main/groovy/wooga/gradle/rust/tasks/AbstractCargoTask.groovy
@@ -386,6 +386,37 @@ abstract class AbstractCargoTask extends DefaultTask implements CargoActionSpec 
         this
     }
 
+    private final DirectoryProperty rustupHome
+
+    @Override
+    @InputDirectory
+    @Optional
+    DirectoryProperty getRustupHome() {
+        rustupHome
+    }
+
+    @Override
+    void setRustupHome(File value) {
+        rustupHome.set(value)
+    }
+
+    @Override
+    void setRustupHome(Provider value) {
+        rustupHome.set(value)
+    }
+
+    @Override
+    CargoActionSpec rustupHome(File value) {
+        setRustupHome(value)
+        this
+    }
+
+    @Override
+    CargoActionSpec rustupHome(Provider value) {
+        setRustupHome(value)
+        this
+    }
+
     AbstractCargoTask() {
         additionalBuildArguments = project.objects.listProperty(String)
         logFile = project.objects.fileProperty()
@@ -398,6 +429,7 @@ abstract class AbstractCargoTask extends DefaultTask implements CargoActionSpec 
         release = project.objects.property(Boolean)
         searchPath = project.objects.fileCollection()
         cargoHome = project.objects.directoryProperty()
+        rustupHome = project.objects.directoryProperty()
         cargoPath = project.objects.fileProperty()
         buildArguments = project.provider({
             List<String> args = []
@@ -466,6 +498,9 @@ abstract class AbstractCargoTask extends DefaultTask implements CargoActionSpec 
                 execSpec.workingDir workingDir.get().asFile.absolutePath
                 execSpec.environment RustInstaller.OS.pathVar, searchPath.asPath
                 execSpec.environment "CARGO_HOME", cargoHome.get().asFile.absolutePath
+                if (rustupHome.present) {
+                    execSpec.environment "RUSTUP_HOME", rustupHome.get().asFile.absolutePath
+                }
                 execSpec.ignoreExitValue = true
                 execSpec.errorOutput = errStream
                 execSpec.standardOutput = outStream


### PR DESCRIPTION
## Description

If the provided cargo command is installed at a non default location, and rustup is also not installed at the non default location then both `RUSTUP_HOME` and `CARGO_HOME` need to point to the respected home directories during cargo invocation. I added yet another property which is optionial to set the `rustupHome` location.

## Changes

* ![FIX] missing `RUSTUP_HOME` set when rustup is not installed at default location

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"